### PR TITLE
fix bug with nock in node 18+

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format:check": "prettier --check **/*.ts",
     "lint": "eslint --fix src/**/*.ts",
     "lint:check": "eslint src/**/*.ts",
-    "test": "jest"
+    "test": "node --no-experimental-fetch node_modules/.bin/jest"
   },
   "repository": {
     "type": "git",
@@ -57,9 +57,8 @@
     "ts-jest": "29.0.3",
     "typescript": "4.9.4"
   },
-  "volta": {
-    "node": "16.19.0",
-    "yarn": "1.22.19"
+  "engines": {
+    "node": ">=20.0.0 <21",
+    "yarn": ">=1.22.0 <2"
   }
 }
-


### PR DESCRIPTION
## what

Add a workaround for a bug in [nock](https://github.com/nock/nock/issues/2397) in node 18+

## why

Node 18+ introduces the fetch api natively and nock doesn't work with that yet. This is a workaround to successfully run test until the issue below is resolved.

## references

https://github.com/nock/nock/issues/2397
