### PR TITLE
Consolidate auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: cloudposse/github-action-auto-release@v1
         with:
           prerelease: false
-          publish: true
+          publish: false
           config-name: auto-release.yml          

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: cloudposse/github-action-auto-release@v1
         with:
-          prerelease: false
           publish: false
+          prerelease: false
           config-name: auto-release.yml          

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,17 +11,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      # Get PR from merged commit to main
-      - uses: actions-ecosystem/action-get-merged-pull-request@v1
-        id: get-merged-pull-request
+      - uses: cloudposse/github-action-auto-release@v1
         with:
-          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-
-      # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5
-        with:
-          publish: false
           prerelease: false
-          config-name: auto-release.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          publish: true
+          config-name: auto-release.yml          


### PR DESCRIPTION
## what
* Use `cloudposse/github-action-auto-release` in `auto-release.yaml` workflow

## why
* Solve old nodejs warning
* Reduce duplication of code
