### PR TITLE
Add `atmos-version-file` input to read the atmos version from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ steps:
       atmos-version: 0.15.0
 ````
 
+The version can also be read from a file with the `atmos-version-file` input. This supports the asdf/mise
+`.tool-versions` format (an `atmos <version>` line) as well as a plain version file whose contents are the version
+(e.g. `.atmos-version`):
+
+```yaml
+steps:
+  - uses: hashicorp/setup-terraform@v2
+
+  - name: Setup atmos
+    uses: cloudposse/github-action-setup-atmos@v2
+    with:
+      atmos-version-file: .tool-versions
+````
+
+When both `atmos-version` and `atmos-version-file` are set, `atmos-version` takes precedence.
+
 The wrapper script installation can be skipped by setting the `install-wrapper` input to `false`:
 
 ```yaml
@@ -114,6 +130,7 @@ steps:
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
 | atmos-version | Version Spec of the version to use. Examples: 1.x, 10.15.1, >=10.15.0. | latest | false |
+| atmos-version-file | Path to a file that declares the atmos version to use. Supports the asdf/mise `.tool-versions` format (an `atmos <version>` line) and a plain version file whose contents are the version (e.g. `.atmos-version`). When both `atmos-version` and `atmos-version-file` are set, `atmos-version` takes precedence. |  | false |
 | checksum-validation | Controls SHA256SUMS validation. Use `warn` to validate when checksums are published and warn when they are missing, `enforce` to fail when checksums are missing, or `skip` to disable checksum validation. Checksum mismatches always fail when validation runs. | warn | false |
 | install-wrapper | Flag to indicate if the wrapper script will be installed to wrap subsequent calls of the `atmos` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. Defaults to `true`. | true | false |
 | token | Used to pull atmos distributions from Cloud Posse's GitHub repository. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. | ${{ github.server\_url == 'https://github.com' && github.token \|\| '' }} | false |

--- a/README.yaml
+++ b/README.yaml
@@ -73,6 +73,22 @@ usage: |-
         atmos-version: 0.15.0
   ````
 
+  The version can also be read from a file with the `atmos-version-file` input. This supports the asdf/mise
+  `.tool-versions` format (an `atmos <version>` line) as well as a plain version file whose contents are the version
+  (e.g. `.atmos-version`):
+
+  ```yaml
+  steps:
+    - uses: hashicorp/setup-terraform@v2
+
+    - name: Setup atmos
+      uses: cloudposse/github-action-setup-atmos@v2
+      with:
+        atmos-version-file: .tool-versions
+  ````
+
+  When both `atmos-version` and `atmos-version-file` are set, `atmos-version` takes precedence.
+
   The wrapper script installation can be skipped by setting the `install-wrapper` input to `false`:
 
   ```yaml

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,12 @@ inputs:
   atmos-version:
     description: "Version Spec of the version to use. Examples: 1.x, 10.15.1, >=10.15.0."
     default: "latest"
+  atmos-version-file:
+    description:
+      Path to a file that declares the atmos version to use. Supports the asdf/mise `.tool-versions` format (an `atmos
+      <version>` line) and a plain version file whose contents are the version (e.g. `.atmos-version`). When both
+      `atmos-version` and `atmos-version-file` are set, `atmos-version` takes precedence.
+    required: false
   install-wrapper:
     description:
       Flag to indicate if the wrapper script will be installed to wrap subsequent calls of the `atmos` binary and expose

--- a/src/__tests__/setup-atmos.test.ts
+++ b/src/__tests__/setup-atmos.test.ts
@@ -453,6 +453,7 @@ describe("Setup Atmos", () => {
         .spyOn(core, "getInput")
         .mockReturnValueOnce("latest")
         .mockReturnValueOnce("")
+        .mockReturnValueOnce("")
         .mockReturnValueOnce("false")
         .mockReturnValueOnce("");
       jest.spyOn(os, "arch").mockReturnValue("x64");
@@ -471,6 +472,7 @@ describe("Setup Atmos", () => {
         .spyOn(core, "getInput")
         .mockReturnValueOnce("latest")
         .mockReturnValueOnce("")
+        .mockReturnValueOnce("")
         .mockReturnValueOnce("true")
         .mockReturnValueOnce("");
       jest.spyOn(os, "arch").mockReturnValue("x64");
@@ -485,6 +487,7 @@ describe("Setup Atmos", () => {
       jest
         .spyOn(core, "getInput")
         .mockReturnValueOnce("latest")
+        .mockReturnValueOnce("")
         .mockReturnValueOnce("arm64")
         .mockReturnValueOnce("true")
         .mockReturnValueOnce("enforce")

--- a/src/__tests__/version-file.test.ts
+++ b/src/__tests__/version-file.test.ts
@@ -1,0 +1,61 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import { getVersionFromFile, parseToolVersions } from "../main";
+
+describe("parseToolVersions", () => {
+  it("returns the atmos version from a .tool-versions file", () => {
+    expect(parseToolVersions("terraform 1.7.0\natmos 1.15.0\n")).toBe("1.15.0");
+  });
+
+  it("ignores comments and blank lines", () => {
+    expect(parseToolVersions("# pinned tools\n\n  atmos   1.13.0  \n")).toBe("1.13.0");
+  });
+
+  it("returns an empty string when atmos is not declared", () => {
+    expect(parseToolVersions("terraform 1.7.0\nhelm 3.14.0\n")).toBe("");
+  });
+
+  it("does not match a tool whose name only contains 'atmos'", () => {
+    expect(parseToolVersions("atmos-pro 2.0.0\n")).toBe("");
+  });
+});
+
+describe("getVersionFromFile", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "atmos-version-file-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { force: true, recursive: true });
+  });
+
+  const write = (name: string, content: string): string => {
+    const filePath = path.join(dir, name);
+    fs.writeFileSync(filePath, content);
+
+    return filePath;
+  };
+
+  it("reads the atmos version from a .tool-versions file", () => {
+    const filePath = write(".tool-versions", "atmos 1.15.0\n");
+    expect(getVersionFromFile(filePath)).toBe("1.15.0");
+  });
+
+  it("reads a plain version file as the version", () => {
+    const filePath = write(".atmos-version", "1.14.0\n");
+    expect(getVersionFromFile(filePath)).toBe("1.14.0");
+  });
+
+  it("throws when the file does not exist", () => {
+    expect(() => getVersionFromFile(path.join(dir, "missing"))).toThrow("does not exist");
+  });
+
+  it("throws when the file is empty", () => {
+    const filePath = write(".tool-versions", "# only comments\n");
+    expect(() => getVersionFromFile(filePath)).toThrow("No atmos version found");
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,81 @@
+import fs from "fs";
 import os from "os";
 
 import * as core from "@actions/core";
 
 import * as installer from "./installer";
 
+const ATMOS_TOOL_NAME = "atmos";
+
+// Parses `.tool-versions` content (asdf/mise format) and returns the atmos
+// version, or an empty string when none is declared. Lines look like
+// `atmos 1.15.0`; comments (`#`) and blank lines are ignored.
+export const parseToolVersions = (content: string): string => {
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const [tool, version] = trimmed.split(/\s+/);
+
+    if (tool === ATMOS_TOOL_NAME && version) {
+      return version;
+    }
+  }
+
+  return "";
+};
+
+// Returns the first non-empty, non-comment line of a plain version file
+// (e.g. `.atmos-version`), or an empty string when there is none.
+const parsePlainVersion = (content: string): string => {
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+
+    if (trimmed && !trimmed.startsWith("#")) {
+      return trimmed;
+    }
+  }
+
+  return "";
+};
+
+// Reads an atmos version from a version file. Supports the asdf/mise
+// `.tool-versions` format (an `atmos <version>` line) and a plain version file
+// whose contents are the version string (e.g. `.atmos-version`).
+export const getVersionFromFile = (filePath: string): string => {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`The atmos-version-file '${filePath}' does not exist`);
+  }
+
+  const content = fs.readFileSync(filePath, "utf8");
+  const version = parseToolVersions(content) || parsePlainVersion(content);
+
+  if (!version) {
+    throw new Error(`No atmos version found in '${filePath}'`);
+  }
+
+  return version;
+};
+
 export const run = async () => {
   try {
-    const versionSpec = core.getInput("atmos-version");
+    let versionSpec = core.getInput("atmos-version");
+    const versionFile = core.getInput("atmos-version-file");
+
+    if (versionFile) {
+      if (versionSpec && versionSpec !== "latest") {
+        core.warning(
+          "Both 'atmos-version' and 'atmos-version-file' inputs are specified, only 'atmos-version' will be used."
+        );
+      } else {
+        versionSpec = getVersionFromFile(versionFile);
+        core.info(`Resolved atmos version '${versionSpec}' from '${versionFile}'`);
+      }
+    }
+
     core.info(`Setup atmos version spec ${versionSpec}`);
 
     const arch = core.getInput("architecture") || os.arch();


### PR DESCRIPTION
## what
* Add an optional `atmos-version-file` input that resolves the atmos version from a file.
* Supports the asdf/mise `.tool-versions` format (an `atmos <version>` line) and a plain version file (e.g. `.atmos-version`).
* When both `atmos-version` and `atmos-version-file` are set, `atmos-version` takes precedence (with a warning).

## why
* Keeps the atmos version in a single source of truth (`.tool-versions`) shared with asdf/mise instead of duplicating it in the workflow.
* Matches the `version-file` pattern now common across setup actions (setup-go, setup-python, golangci-lint-action).

## references
* closes #97